### PR TITLE
fix: set `publishConfig` to public

### DIFF
--- a/packages/hoc/package.json
+++ b/packages/hoc/package.json
@@ -2,6 +2,9 @@
   "name": "@react-qui/hoc",
   "version": "0.1.0",
   "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "lib"
   ],


### PR DESCRIPTION
- set `publishConfig` of `@react-qui/hoc` to `public`